### PR TITLE
update/override configuration

### DIFF
--- a/src/checks.rs
+++ b/src/checks.rs
@@ -4,11 +4,11 @@ use crate::config::{Challenge, Method};
 use rand::Rng;
 use rayon::prelude::*;
 use regex::Regex;
-use serde_derive::Deserialize;
+use serde_derive::{Deserialize, Serialize};
 use std::io;
 
 /// Describe single check
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Check {
     pub is: String,
     pub method: Method,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,10 @@
 
 use clap::{crate_name, crate_version, App, Arg};
 
+pub const UPDATE_CONFIGURATION_OVERRIDE: &str = "override";
+
+pub const UPDATE_CONFIGURATION_ONLY_DIFF: &str = "only-diff";
+
 pub fn get_app() -> App<'static> {
     App::new(crate_name!())
         .version(crate_version!())
@@ -23,6 +27,19 @@ pub fn get_app() -> App<'static> {
                         .help("get the user command that should run.")
                         .required(true)
                         .takes_value(true),
+                ),
+        )
+        .subcommand(
+            App::new("update-configuration")
+                .about("Update configuration file")
+                .arg(
+                    Arg::new("behaver")
+                        .short('b')
+                        .long("behaver")
+                        .help("The behaver of the update, you can replace your existing one with the default config application or just add new checks")
+                        .possible_values(&[UPDATE_CONFIGURATION_OVERRIDE, UPDATE_CONFIGURATION_ONLY_DIFF])
+                        .default_value(UPDATE_CONFIGURATION_ONLY_DIFF)
+                        .takes_value(true)
                 ),
         )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,16 +23,16 @@ fn main() {
         exit(1);
     }
 
-    let conf = match config_dir.load_config_from_file() {
-        Ok(conf) => conf,
-        Err(e) => {
-            eprintln!("Error: {}", e.to_string());
-            exit(1)
-        }
-    };
-
     if let Some(validate_matches) = matches.subcommand_matches("pre-command") {
         let command = validate_matches.value_of("command").unwrap();
+
+        let conf = match config_dir.load_config_from_file() {
+            Ok(conf) => conf,
+            Err(e) => {
+                eprintln!("Error: {}", e.to_string());
+                exit(1)
+            }
+        };
 
         let matches = checks::run_check_on_command(&conf.checks, command);
 
@@ -47,6 +47,16 @@ fn main() {
         }
 
         exit(should_continue);
+    }
+    if let Some(validate_matches) = matches.subcommand_matches("update-configuration") {
+        let behaver = validate_matches.value_of("behaver").unwrap();
+        if let Err(err) = config_dir.update_config_content(behaver) {
+            eprintln!(
+                "Error while trying to update configuration. Error: {}",
+                err.to_string()
+            );
+            exit(1)
+        }
     } else {
         app.print_long_help().unwrap();
     }


### PR DESCRIPTION
we need the option to release new configuration files to all the clients when config.yaml already exists.
Created new command `update-configuration` with behaver flag
1. replace the config.yaml
2. add only the checks that not exists (for new check release)