### PR TITLE
add the option to backup config file before using config update command

### DIFF
--- a/checks/fs.yaml
+++ b/checks/fs.yaml
@@ -1,5 +1,5 @@
 - from: fs
-  is: rm.+(-r\b|-f\b|-rf\b|-fr\b).*(\/|\*)\s
+  is: rm.+(-r|-fr|-rf)(\s*)(/|\*)(\s*)\z
   method: Regex
   enable: true
   description: "You are going to delete everything in the path."
@@ -14,7 +14,7 @@
   enable: true
   description: "The above command is used to flush the content of file."
 - from: fs
-  is: \s*chmod.*-R.* (\/|\*|\/\*)\s*$
+  is: chmod.+(-R)\s+[0-9].+(/|\*)(\s*)\z
   method: Regex
   enable: true
   description: "Change permission to all root files can brake your some thinks like SSH keys."

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,9 @@ use anyhow::Result as AnyResult;
 use log::debug;
 use serde_derive::{Deserialize, Serialize};
 use std::fs;
+use std::io;
 use std::io::{Read, Write};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Default configuration file.
 pub const DEFAULT_CONFIG_FILE: &str = include_str!("config.yaml");
@@ -108,7 +110,33 @@ impl SettingsConfig {
     ///
     // TODO:: need to test this function
     pub fn reset_config(&self) -> AnyResult<()> {
-        self.create_default_config_file()?;
+        eprintln!(
+            "Rest configuration will reset all checks settings. Select how to continue...\n{}\n{}\n{}",
+            "1. Yes, i want to override the current configuration".to_string(),
+            "2. Override and backup the existing file".to_string(),
+            "3. Cancel Or ^C".to_string()
+        );
+        let mut answer = String::new();
+        io::stdin()
+            .read_line(&mut answer)
+            .expect("Failed to read line");
+
+        match answer.trim() {
+            "1" => self.create_default_config_file()?,
+            "2" => {
+                fs::rename(
+                    &self.config_file_path,
+                    format!(
+                        "{}.back.{}",
+                        self.config_file_path,
+                        SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs()
+                    ),
+                )?;
+                self.create_default_config_file()?
+            }
+            _ => return Err(anyhow!("unexpected option")),
+        };
+
         Ok(())
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,7 +127,7 @@ impl SettingsConfig {
                 fs::rename(
                     &self.config_file_path,
                     format!(
-                        "{}.back.{}",
+                        "{}.{}.bak",
                         self.config_file_path,
                         SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs()
                     ),


### PR DESCRIPTION
Before restoring the user setting when running the command:`shellfirm config reset `  I want to show the user that all his changes (if was) config to destroy + adding the ability to create a backup file for restore.