### PR TITLE
add custom filter

### DIFF
--- a/checks/fs-strict.yaml
+++ b/checks/fs-strict.yaml
@@ -8,8 +8,3 @@
   method: Regex
   enable: true
   description: "Are you sure you want to continue with deletion?"
-- from: fs-strict
-  test: ([[:alnum:]]|[[:punct:]])> *.+
-  method: Regex
-  enable: true
-  description: "The command going to override your file content."

--- a/checks/fs.yaml
+++ b/checks/fs.yaml
@@ -9,10 +9,12 @@
   enable: true
   description: "The files will be discarded and destroyed."
 - from: fs
-  test: ^\s*> *.+
+  test: .*>(.*)
   method: Regex
   enable: true
   description: "The above command is used to flush the content of a file."
+  filters:
+    IsFileExists: "1"
 - from: fs
   test: chmod\s*(-R)\s+[0-9]{1,}\s*(\*|\.\z|\./\z|\.\.|\.|/)
   method: Regex

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ pub const DEFAULT_CONFIG_FILE: &str = include_str!("config.yaml");
 pub const ALL_CHECKS: &str = include_str!(concat!(env!("OUT_DIR"), "/all-checks.yaml"));
 
 /// The method type go the check.
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub enum Method {
     /// Run start with check.
     StartWith,
@@ -387,6 +387,7 @@ mod config {
             description: String::from("description"),
             from: String::from("from"),
             challenge: Challenge::Default,
+            filters: std::collections::HashMap::new(),
         }];
 
         assert!(settings_config
@@ -416,6 +417,7 @@ mod config {
             description: String::from("description"),
             from: String::from(""),
             challenge: Challenge::Default,
+            filters: std::collections::HashMap::new(),
         }];
 
         assert!(settings_config
@@ -441,6 +443,7 @@ mod config {
             description: String::from("description"),
             from: String::from("test"),
             challenge: Challenge::Default,
+            filters: std::collections::HashMap::new(),
         }];
 
         assert!(settings_config

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ fn main() {
             exit(0);
         } else if validate_matches.subcommand_matches("reset").is_some() {
             if let Err(err) = config_dir.reset_config() {
-                eprintln!("Could not reset settings{}", err.to_string());
+                eprintln!("Could not reset settings {}", err.to_string());
                 exit(1)
             }
 


### PR DESCRIPTION
Adding the option to define a custom filter to the match. 
for example if user runs the command : `some content > file.txt`
and the files not exists, we don't need to prompt a double verification challenge