### PR TITLE
Adds crontab -r as a risky command

### DIFF
--- a/shellfirm/checks/base.yaml
+++ b/shellfirm/checks/base.yaml
@@ -4,6 +4,11 @@
   enable: true
   description: "This short line defines a shell function that creates new copies of itself.\nThe process continually replicates itself, and its copies continually replicate themselves, quickly taking up all your CPU time and memory.\nThis can cause your computer to freeze. It’s basically a denial-of-service attack."
 - from: base
+  test: \s*crontab\s+-r
+  method: Regex
+  enable: true
+  description: "You are going to remove your entire table of cron tasks."
+- from: base
   test: \s*history.*.[|].*.(bash|sh)
   method: Regex
   enable: true


### PR DESCRIPTION
A naive regex to catch execution of the risky crontab -r command, fixes issue #80