### PR TITLE
fix: force direct tty prompts for zsh hook

### DIFF
--- a/shellfirm/src/bin/cmd/command.rs
+++ b/shellfirm/src/bin/cmd/command.rs
@@ -34,6 +34,13 @@ pub fn command() -> Command {
                 .help("Check if the command is risky and exit")
                 .action(ArgAction::SetTrue),
         )
+        .arg(
+            Arg::new("direct-tty")
+                .long("direct-tty")
+                .help("Read prompts directly from /dev/tty")
+                .hide(true)
+                .action(ArgAction::SetTrue),
+        )
 }
 
 pub fn run(
@@ -53,7 +60,7 @@ pub fn run(
     // which reads from /dev/tty with simple cooked-mode line I/O.
     // See: https://github.com/kaplanelad/shellfirm/issues/160
     #[cfg(unix)]
-    if !std::io::stdin().is_terminal() {
+    if arg_matches.get_flag("direct-tty") || !std::io::stdin().is_terminal() {
         let prompter = shellfirm::prompt::DirectTtyPrompter;
         return execute(command, settings, checks, dryrun, &env, &prompter, config);
     }

--- a/shellfirm/src/bin/cmd/init.rs
+++ b/shellfirm/src/bin/cmd/init.rs
@@ -780,7 +780,7 @@ shellfirm-pre-command() {
         zle .accept-line
         return
     fi
-    shellfirm pre-command -c "${BUFFER}"
+    shellfirm pre-command --direct-tty -c "${BUFFER}"
     if [[ $? -eq 0 ]]; then
         zle .accept-line
     else
@@ -1132,6 +1132,15 @@ mod tests {
                 "{shell} hook must contain 'shellfirm pre-command' for interception"
             );
         }
+    }
+
+    #[test]
+    fn zsh_hook_uses_direct_tty_prompt() {
+        let hook = Shell::Zsh.hook();
+        assert!(
+            hook.contains("shellfirm pre-command --direct-tty"),
+            "zsh hook must force DirectTtyPrompter to avoid crossterm hangs in zle"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the zsh hook path so it explicitly uses Shellfirm's direct `/dev/tty` prompter instead of relying on `stdin().is_terminal()` to infer whether requestty/crossterm is safe.

## Root Cause

`pre-command` already has a `DirectTtyPrompter` fallback for zsh zle contexts, but it is selected only when stdin is not a terminal. In some zsh hook environments stdin still reports as a terminal, so Shellfirm selects `TerminalPrompter`, enters requestty/crossterm, emits a cursor-position query, and can hang without showing a usable prompt.

## Changes

- Adds a hidden `pre-command --direct-tty` flag that forces `DirectTtyPrompter` on Unix.
- Updates the generated zsh hook to call `shellfirm pre-command --direct-tty -c "${BUFFER}"`.
- Adds a regression test asserting the generated zsh hook keeps the direct-tty flag.

Fixes #183.

## Verification

- `cargo test -p shellfirm zsh_hook_uses_direct_tty_prompt`
- `cargo test -p shellfirm command`
- Runtime smoke test with `target/debug/shellfirm pre-command --direct-tty -c 'rm -rf /private/tmp/shellfirm-pr-runtime-test'`, confirming it shows `Type 'yes' to continue` instead of entering the hanging cursor-query path.
